### PR TITLE
Kunai logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@
 
 # files from test
 apks/
+*.log
 
 # objects and bins
 objs/

--- a/make.sh
+++ b/make.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+# make file in bash made mainly for debian
+# this should be modified once more OS are
+# included.
+
+
+# taken from capstone
+MAKE_JOBS=$((${MAKE_JOBS}+0))
+[ ${MAKE_JOBS} -lt 1 ] && \
+  MAKE_JOBS=4
+
+COMPILER=g++
+
+check_and_build_dependencies() {
+    echo "[+] Checking for package libspdlog-dev"
+    dpkg -s libspdlog-dev 2> /dev/null > /dev/null
+    if [ $? -ne 0 ]; then
+        echo "[-] libspdlog-dev not installed, installing it..."
+        sudo apt install libspdlog-dev
+    fi
+}
+
+
+build_kunai() {
+    # check if dependencies are not installed.
+    check_and_build_dependencies
+
+    echo "[+] Compiling KUNAI with ${MAKE_JOBS} jobs"
+
+    CXX=${COMPILER} make --silent -j${MAKE_JOBS}
+
+    if [ $? -ne 0 ]; then
+        echo "[-] An error ocurred, check output..."
+        exit 1
+    fi
+
+    echo "[+] KUNAI compiled correctly"
+}
+
+install_kunai() {
+    # install kunai on system
+
+    echo "[+] Installing KUNAI, compiling first..."
+    build_kunai
+    echo "[+] Installing on system"
+    make install
+
+    if [ $? -ne 0 ]; then
+        echo "[-] An error ocurred while installing..."
+        exit 1
+    fi
+}
+
+uninstall_kunai() {
+    echo "[+] Uninstalling KUNAI from system"
+    make remove
+
+    if [ $? -ne 0 ]; then
+        echo "[-] An error ocurred while uninstalling..."
+        exit 1
+    fi
+
+    echo "[+] KUNAI uninstalled correctly"
+}
+
+run_tests() {
+    echo "[+] Running tests"
+    ./run_tests.sh
+}
+
+[ -z "${UNAME}" ] && UNAME=$(uname)
+
+TARGET="$1"
+[ -n "$TARGET" ] && shift
+
+
+if [ ${UNAME} != "Linux" ]; then
+    echo "[-] System not supported yet"
+    exit 1
+fi
+
+case "$TARGET" in
+    "" ) 
+        build_kunai;;
+    "install" ) 
+        install_kunai;;
+    "uninstall" )
+        uninstall_kunai;;
+    "dependencies" ) 
+        check_and_build_dependencies;;
+    "clang" ) 
+        COMPILER=clang++ 
+        build_kunai;;
+    "run_tests" )
+        run_tests;;
+    * )
+        echo "Usage: $0 ["`grep '^  "' $0 | cut -d '"' -f 2 | tr "\\n" "|"`"]"
+        exit 1;;
+esac

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+LOG_FILE=run_tests_output.log
+
+echo "[+] Running KUNAI tests"
+
+if [ ! -d "./bin/tests/" ]; then
+    echo "[-] Please compile KUNAI before running tests"
+    exit 1
+fi
+
+echo "run_tests.sh output" > ${LOG_FILE}
+
+echo "[+] Running 'test_ir' test"
+
+if [ ! -f "./bin/tests/test_ir" ]; then
+    echo "[-] File does not exists"
+    exit 1
+fi
+
+echo "Log 'test_ir'" >> ${LOG_FILE}
+./bin/tests/test_ir 2>> ${LOG_FILE}
+
+if [ $? -eq 0 ]; then
+    echo "[!] Test succeeded"
+else
+    echo "[-] Error passing test"
+fi

--- a/src/DEX/Analysis/dex_analysis.cpp
+++ b/src/DEX/Analysis/dex_analysis.cpp
@@ -6,8 +6,8 @@ namespace KUNAI
     {
 
         Analysis::Analysis(std::shared_ptr<DexParser> dex_parser, std::shared_ptr<DalvikOpcodes> dalvik_opcodes, std::map<std::tuple<std::shared_ptr<ClassDef>, std::shared_ptr<EncodedMethod>>, std::map<std::uint64_t, std::shared_ptr<Instruction>>> instructions) : created_xrefs(false),
-                                                                                                                                                                                                                                                                         dalvik_opcodes(dalvik_opcodes),
-                                                                                                                                                                                                                                                                         instructions(instructions)
+                                                                                                                                                                                                                                                                        dalvik_opcodes(dalvik_opcodes),
+                                                                                                                                                                                                                                                                        instructions(instructions)
         {
             if (dex_parser)
                 this->add(dex_parser);
@@ -195,8 +195,8 @@ namespace KUNAI
         {
             std::vector<std::shared_ptr<MethodAnalysis>> methods;
 
-            for (auto it = method_hashes.begin(); it != method_hashes.end(); it++)
-                methods.push_back(it->second);
+            for (auto hash : method_hashes)
+                methods.push_back(hash.second);
 
             return methods;
         }
@@ -215,9 +215,9 @@ namespace KUNAI
         {
             std::vector<std::shared_ptr<FieldAnalysis>> fields;
 
-            for (auto it = classes.begin(); it != classes.end(); it++)
+            for (auto c : classes)
             {
-                auto aux = it->second->get_fields();
+                auto aux = c.second->get_fields();
 
                 fields.insert(std::end(fields), std::begin(aux), std::end(aux));
             }
@@ -229,9 +229,9 @@ namespace KUNAI
         {
             std::vector<std::shared_ptr<StringAnalysis>> str_vector;
 
-            for (auto it = strings.begin(); it != strings.end(); it++)
+            for (auto s : strings)
             {
-                str_vector.push_back(it->second);
+                str_vector.push_back(s.second);
             }
 
             return str_vector;
@@ -242,12 +242,12 @@ namespace KUNAI
             std::vector<std::shared_ptr<ClassAnalysis>> classes_vector;
             std::regex class_name_regex(name);
 
-            for (auto it = classes.begin(); it != classes.end(); it++)
+            for (auto c : classes)
             {
-                if (no_external && (it->second->is_class_external()))
+                if (no_external && (c.second->is_class_external()))
                     continue;
-                if (std::regex_search(it->second->name(), class_name_regex))
-                    classes_vector.push_back(it->second);
+                if (std::regex_search(c.second->name(), class_name_regex))
+                    classes_vector.push_back(c.second);
             }
 
             return classes_vector;
@@ -266,21 +266,21 @@ namespace KUNAI
                 descriptor_regex(descriptor),
                 accessflags_regex(accessflags);
 
-            for (auto c = classes.begin(); c != classes.end(); c++)
+            for (auto c : classes)
             {
-                if (std::regex_search(c->second->name(), class_name_regex))
+                if (std::regex_search(c.second->name(), class_name_regex))
                 {
-                    auto methods = c->second->get_methods();
+                    auto methods = c.second->get_methods();
 
-                    for (auto m = methods.begin(); m != methods.end(); m++)
+                    for (auto m : methods)
                     {
-                        if (no_external && (*m)->external())
+                        if (no_external && m->external())
                             continue;
 
-                        if (std::regex_search((*m)->name(), method_name_regex) &&
-                            std::regex_search((*m)->descriptor(), descriptor_regex) &&
-                            std::regex_search((*m)->access(), accessflags_regex))
-                            methods_vector.push_back(*m);
+                        if (std::regex_search(m->name(), method_name_regex) &&
+                            std::regex_search(m->descriptor(), descriptor_regex) &&
+                            std::regex_search(m->access(), accessflags_regex))
+                            methods_vector.push_back(m);
                     }
                 }
             }
@@ -314,18 +314,18 @@ namespace KUNAI
 
             std::vector<std::shared_ptr<FieldAnalysis>> fields_list;
 
-            for (auto c = classes.begin(); c != classes.end(); c++)
+            for (auto c : classes)
             {
-                if (std::regex_search(c->second->name(), class_name_regex))
+                if (std::regex_search(c.second->name(), class_name_regex))
                 {
-                    auto fields = c->second->get_fields();
-                    for (auto f = fields.begin(); f != fields.end(); f++)
+                    auto fields = c.second->get_fields();
+                    for (auto f : fields)
                     {
-                        if (std::regex_search((*f)->name(), field_name_regex) &&
-                            std::regex_search((*f)->get_field()->get_field()->get_type_idx()->get_raw(), field_type_regex) &&
-                            std::regex_search(dalvik_opcodes->get_access_flags_string((*f)->get_field()->get_access_flags()), accessflags_regex))
+                        if (std::regex_search(f->name(), field_name_regex) &&
+                            std::regex_search(f->get_field()->get_field()->get_type_idx()->get_raw(), field_type_regex) &&
+                            std::regex_search(dalvik_opcodes->get_access_flags_string(f->get_field()->get_access_flags()), accessflags_regex))
                         {
-                            fields_list.push_back(*f);
+                            fields_list.push_back(f);
                         }
                     }
                 }

--- a/src/DEX/Analysis/dex_class_analysis.cpp
+++ b/src/DEX/Analysis/dex_class_analysis.cpp
@@ -34,7 +34,7 @@ namespace KUNAI
 
             auto class_def = std::dynamic_pointer_cast<ClassDef>(this->class_def);
 
-            for (size_t i = 0; class_def->get_number_of_interfaces(); i++)
+            for (size_t i = 0, n_of_interfaces = class_def->get_number_of_interfaces(); i < n_of_interfaces ; i++)
                 implemented_interfaces.push_back(class_def->get_interface_by_pos(i));
 
             return implemented_interfaces;
@@ -71,9 +71,9 @@ namespace KUNAI
 
             std::string class_name = this->name();
 
-            for (auto it = known_apis.begin(); it != known_apis.end(); it++)
+            for (auto known_api : known_apis)
             {
-                if (class_name.find(*it) == 0)
+                if (class_name.find(known_api) == 0)
                     return true;
             }
 

--- a/src/DEX/Analysis/dex_dvm_basic_block.cpp
+++ b/src/DEX/Analysis/dex_dvm_basic_block.cpp
@@ -32,10 +32,10 @@ namespace KUNAI
         {
             std::vector<std::shared_ptr<Instruction>> bb_instructions;
 
-            for (auto it = this->instructions.begin(); it != this->instructions.end(); it++)
+            for (auto instruction : instructions)
             {
-                if ((start <= it->first) && (it->first < end))
-                    bb_instructions.push_back(it->second);
+                if ((start <= instruction.first) && (instruction.first < end))
+                    bb_instructions.push_back(instruction.second);
             }
 
             return bb_instructions;
@@ -60,13 +60,13 @@ namespace KUNAI
                 childs.push_back({end - last_length, end, next_block});
             }
 
-            for (auto it = childs.begin(); it != childs.end(); it++)
+            for (auto child : childs)
             {
-                auto child_block = std::get<2>(*it);
+                auto child_block = std::get<2>(child);
                 if (child_block != nullptr)
                 {
-                    auto last_idx = std::get<1>(*it);
-                    auto end_idx = std::get<0>(*it);
+                    auto last_idx = std::get<1>(child);
+                    auto end_idx = std::get<0>(child);
                     child_block->set_parent({last_idx, end_idx, this});
                 }
             }
@@ -150,11 +150,11 @@ namespace KUNAI
 
         std::shared_ptr<DVMBasicBlock> BasicBlocks::get_basic_block_by_idx(std::uint64_t idx)
         {
-            for (auto it = this->basic_blocks.begin(); it != this->basic_blocks.end(); it++)
+            for (auto basic_block : basic_blocks)
             {
-                if ((it->get()->get_start() <= idx) && (idx < it->get()->get_end()))
+                if ((basic_block.get()->get_start() <= idx) && (idx < basic_block.get()->get_end()))
                 {
-                    return *it;
+                    return basic_block;
                 }
             }
 

--- a/src/DEX/Analysis/dex_exception_analysis.cpp
+++ b/src/DEX/Analysis/dex_exception_analysis.cpp
@@ -56,12 +56,12 @@ namespace KUNAI
 
         std::shared_ptr<ExceptionAnalysis> Exception::get_exception(std::uint64_t start_addr, std::uint64_t end_addr)
         {
-            for (auto it = exceptions.begin(); it != exceptions.end(); it++)
+            for (auto exception : exceptions)
             {
-                if (((*it)->get().try_value_start_addr >= start_addr) && ((*it)->get().try_value_end_addr <= end_addr))
-                    return *it;
-                else if ((end_addr <= (*it)->get().try_value_end_addr) && (start_addr >= (*it)->get().try_value_start_addr))
-                    return *it;
+                if (((*exception).get().try_value_start_addr >= start_addr) && ((*exception).get().try_value_end_addr <= end_addr))
+                    return exception;
+                else if ((end_addr <= (*exception).get().try_value_end_addr) && (start_addr >= (*exception).get().try_value_start_addr))
+                    return exception;
             }
 
             return nullptr;

--- a/src/DEX/Analysis/dex_method_analysis.cpp
+++ b/src/DEX/Analysis/dex_method_analysis.cpp
@@ -148,6 +148,8 @@ namespace KUNAI
 
         void MethodAnalysis::create_basic_block()
         {
+            auto logger = LOGGER::logger();
+
             basic_blocks = std::make_shared<BasicBlocks>();
             std::shared_ptr<DVMBasicBlock> current_basic = std::make_shared<DVMBasicBlock>(0, dalvik_opcodes, basic_blocks, std::dynamic_pointer_cast<EncodedMethod>(method_encoded), instructions);
 
@@ -157,7 +159,8 @@ namespace KUNAI
             std::vector<std::int64_t> l;
             std::map<std::uint64_t, std::vector<std::int64_t>> h;
 
-            std::cout << "Parsing the instructions for method " << std::hex << std::dynamic_pointer_cast<EncodedMethod>(method_encoded)->full_name() << std::endl;
+            logger->debug("create_basic_block: creating basic blocks for method {}.", std::dynamic_pointer_cast<EncodedMethod>(method_encoded)->full_name());
+
             for (auto const &instruction : instructions)
             {
                 auto idx = std::get<0>(instruction);
@@ -172,7 +175,7 @@ namespace KUNAI
                 }
             }
 
-            std::cout << "Parsing the exceptions" << std::endl;
+            logger->debug("create_basic_block: parsing method exceptions.");
 
             auto excepts = determine_exception(dalvik_opcodes, std::dynamic_pointer_cast<EncodedMethod>(method_encoded));
 
@@ -186,7 +189,8 @@ namespace KUNAI
                 }
             }
 
-            std::cout << "Creating basic blocks" << std::endl;
+            logger->debug("create_basic_block: creating the basic blocks with references.");
+
             for (const auto &instruction : instructions)
             {
                 auto idx = std::get<0>(instruction);
@@ -215,14 +219,16 @@ namespace KUNAI
                 basic_blocks->pop_basic_block();
             }
 
-            std::cout << "Settings basic blocks childs" << std::endl;
+            logger->debug("create_basic_blocks: setting basic blocks childs.");
+            
             auto bbs = basic_blocks->get_basic_blocks();
             for (auto bb : bbs)
             {
                 bb->set_child(h[bb->get_end() - bb->get_last_length()]);
             }
 
-            std::cout << "Creating exceptions" << std::endl;
+            logger->debug("create_basic_blocks: creating exceptions.");
+            
             this->exceptions->add(excepts, this->basic_blocks);
 
             for (auto bb : bbs)

--- a/src/DEX/Analysis/dex_method_analysis.cpp
+++ b/src/DEX/Analysis/dex_method_analysis.cpp
@@ -173,7 +173,9 @@ namespace KUNAI
             }
 
             std::cout << "Parsing the exceptions" << std::endl;
+
             auto excepts = determine_exception(dalvik_opcodes, std::dynamic_pointer_cast<EncodedMethod>(method_encoded));
+
             for (const auto &except : excepts)
             {
                 l.push_back(except.try_value_start_addr);

--- a/src/DEX/DVM/dex_instructions.cpp
+++ b/src/DEX/DVM/dex_instructions.cpp
@@ -1985,9 +1985,9 @@ namespace KUNAI
                 if (h_off.find(encoded_catch_handler->get_offset()) == h_off.end())
                     continue;
 
-                for (size_t i = 0; i < h_off[encoded_catch_handler->get_offset()].size(); i++)
+                for (size_t j = 0; j < h_off[encoded_catch_handler->get_offset()].size(); j++)
                 {
-                    h_off[encoded_catch_handler->get_offset()][i].push_back(encoded_catch_handler);
+                    h_off[encoded_catch_handler->get_offset()][j].push_back(encoded_catch_handler);
                 }
             }
 

--- a/src/DEX/parser/dex_classes.cpp
+++ b/src/DEX/parser/dex_classes.cpp
@@ -285,13 +285,15 @@ namespace KUNAI
                 class_data_items = std::make_shared<ClassDataItem>(input_file, file_size, dex_fields, dex_methods, dex_types);
             }
 
+            /**
             if (static_values_off > 0)
             {
                 input_file.seekg(static_values_off);
 
                 static_values = std::make_shared<EncodedArrayItem>(input_file);
             }
-
+            */
+           
             input_file.seekg(current_offset);
             return true;
         }
@@ -364,7 +366,7 @@ namespace KUNAI
             input_file.seekg(offset);
 
             for (i = 0; i < number_of_classes; i++)
-            {
+            {                
                 if (!KUNAI::read_data_file<ClassDef::classdef_t>(class_def_struct, sizeof(ClassDef::classdef_t), input_file))
                     return false;
 
@@ -409,7 +411,8 @@ namespace KUNAI
             for (auto class_def : entry.class_defs)
             {
                 os << "Class (" << i++ << "):" << std::endl;
-                os << "\tClass idx: " << class_def->get_class_idx()->get_name() << std::endl;
+                if (class_def->get_class_idx())
+                    os << "\tClass idx: " << class_def->get_class_idx()->get_name() << std::endl;
                 os << "\tAccess Flags: " << class_def->get_access_flags() << std::endl;
                 if (class_def->get_superclass_idx())
                     os << "\tSuperclass: " << class_def->get_superclass_idx()->get_name() << std::endl;

--- a/src/DEX/parser/dex_classes.cpp
+++ b/src/DEX/parser/dex_classes.cpp
@@ -233,6 +233,7 @@ namespace KUNAI
             this->annotations_off = class_def.annotations_off;
             this->classess_off = class_def.class_data_off;
             this->static_values_off = class_def.static_values_off;
+
             if (!parse_class_defs(input_file, file_size, dex_str, dex_types, dex_fields, dex_methods))
                 throw exceptions::ParserReadingException("Error reading DEX ClassDef");
         }
@@ -244,10 +245,14 @@ namespace KUNAI
                                         std::shared_ptr<DexFields> dex_fields,
                                         std::shared_ptr<DexMethods> dex_methods)
         {
+            auto logger = LOGGER::logger();
+
             auto current_offset = input_file.tellg();
             size_t i;
             std::uint32_t size;
             std::uint16_t interface;
+
+            logger->debug("ClassDef parsing values from class");
 
             // parse first the interfaces
             if (interfaces_off > 0)
@@ -256,6 +261,8 @@ namespace KUNAI
 
                 if (!KUNAI::read_data_file<std::uint32_t>(size, sizeof(std::uint32_t), input_file))
                     return false;
+
+                logger->debug("Parsing interfaces with offset {} and size {}", interfaces_off, size);
 
                 for (i = 0; i < size; i++)
                 {
@@ -274,6 +281,8 @@ namespace KUNAI
             {
                 input_file.seekg(annotations_off);
 
+                logger->debug("Parsing AnnotationsDirectoryItem in offset {}", annotations_off);
+
                 annotation_directory_item = std::make_shared<AnnotationsDirectoryItem>(input_file);
             }
 
@@ -281,6 +290,8 @@ namespace KUNAI
             if (classess_off > 0)
             {
                 input_file.seekg(classess_off);
+
+                logger->debug("Parsing ClassDataItem in offset {}", classess_off);
 
                 class_data_items = std::make_shared<ClassDataItem>(input_file, file_size, dex_fields, dex_methods, dex_types);
             }
@@ -358,6 +369,8 @@ namespace KUNAI
 
         bool DexClasses::parse_classes(std::ifstream &input_file, std::uint64_t file_size)
         {
+            auto logger = LOGGER::logger();
+
             auto current_offset = input_file.tellg();
             size_t i;
             ClassDef::classdef_t class_def_struct;
@@ -365,40 +378,71 @@ namespace KUNAI
 
             input_file.seekg(offset);
 
+            logger->debug("DexClasses start parsing at offset {} and size {}", offset, number_of_classes);
+
             for (i = 0; i < number_of_classes; i++)
             {                
                 if (!KUNAI::read_data_file<ClassDef::classdef_t>(class_def_struct, sizeof(ClassDef::classdef_t), input_file))
                     return false;
 
                 if (class_def_struct.class_idx >= dex_types->get_number_of_types())
+                {
+                    logger->error("Error reading DEX classes class_idx out of type bound ({} >= {})", class_def_struct.class_idx, dex_types->get_number_of_types());
                     throw exceptions::IncorrectTypeId("Error reading DEX classes class_idx out of type bound");
+                }
 
                 if (class_def_struct.access_flags > DVMTypes::ACC_DECLARED_SYNCHRONIZED)
+                {
+                    logger->error("Error reading DEX classes access_flags incorrect value ({})", class_def_struct.access_flags);
                     throw exceptions::IncorrectValue("Error reading DEX classes access_flags incorrect value");
+                }
 
                 if ((class_def_struct.superclass_idx != DVMTypes::NO_INDEX) && (class_def_struct.superclass_idx >= dex_types->get_number_of_types()))
+                {
+                    logger->error("Error reading DEX classes superclass_idx out of type bound ({} >= {})", class_def_struct.superclass_idx, dex_types->get_number_of_types());
                     throw exceptions::IncorrectTypeId("Error reading DEX classes superclass_idx out of type bound");
+                }
 
                 if (class_def_struct.interfaces_off > file_size)
+                {
+                    logger->error("Error reading DEX classes interfaces_off out of file bound ({} > {})", class_def_struct.interfaces_off, file_size);
                     throw exceptions::OutOfBoundException("Error reading DEX classes interfaces_off out of file bound");
+                }
 
                 if ((class_def_struct.source_file_idx != DVMTypes::NO_INDEX) && (class_def_struct.source_file_idx >= dex_str->get_number_of_strings()))
+                {
+                    logger->error("Error reading DEX classes source_file_idx out of string bound ({} >= {})", class_def_struct.source_file_idx, dex_str->get_number_of_strings());
                     throw exceptions::IncorrectStringId("Error reading DEX classes source_file_idx out of string bound");
+                }
 
                 if (class_def_struct.annotations_off > file_size)
+                {
+                    logger->error("Error reading DEX classes annotations_off out of file bound ({} > {})", class_def_struct.annotations_off, file_size);
                     throw exceptions::OutOfBoundException("Error reading DEX classes annotations_off out of file bound");
+                }
 
                 if (class_def_struct.class_data_off > file_size)
+                {
+                    logger->error("Error reading DEX classes class_data_off out of file bound ({} > {})", class_def_struct.class_data_off, file_size);
                     throw exceptions::OutOfBoundException("Error reading DEX classes class_data_off out of file bound");
+                }
 
                 if (class_def_struct.static_values_off > file_size)
+                {
+                    logger->error("Error reading DEX classes static_values_off out of file bound ({} > {})", class_def_struct.static_values_off, file_size);
                     throw exceptions::OutOfBoundException("Error reading DEX classes static_values_off out of file bound");
+                }
 
                 class_def = std::make_shared<ClassDef>(class_def_struct, dex_str, dex_types, dex_fields, dex_methods, input_file, file_size);
                 class_defs.push_back(class_def);
+
+                logger->debug("parsed class_def number {}", i);
             }
 
             input_file.seekg(current_offset);
+
+            logger->info("DexClasses parsing correct");
+
             return true;
         }
 

--- a/src/DEX/parser/dex_encoded.cpp
+++ b/src/DEX/parser/dex_encoded.cpp
@@ -49,7 +49,7 @@ namespace KUNAI
             }
             case DVMTypes::VALUE_ANNOTATION:
             {
-                // ToDo
+                annotation = std::make_shared<EncodedAnnotation>(input_file);
                 break;
             }
             case DVMTypes::VALUE_NULL:
@@ -336,6 +336,38 @@ namespace KUNAI
 
             input_file.seekg(current_offset);
             return true;
+        }
+
+        /**
+         * AnnotationElement
+         */
+        AnnotationElement::AnnotationElement(std::ifstream& input_file)
+        {
+            name_idx = read_uleb128(input_file);
+            value = std::make_shared<EncodedValue>(input_file);
+        }
+        
+        /**
+         * EncodedAnnotation
+         */
+        EncodedAnnotation::EncodedAnnotation(std::ifstream& input_file)
+        {
+            type_idx = read_uleb128(input_file);
+            size = read_uleb128(input_file);
+
+            std::shared_ptr<AnnotationElement> annotation_element;
+
+            for (size_t i = 0; i < size; i++)
+            {
+                annotation_element = std::make_shared<AnnotationElement>(input_file);
+                elements.push_back(annotation_element);    
+            }
+        }
+
+        EncodedAnnotation::~EncodedAnnotation()
+        {
+            if (!elements.empty())
+                elements.clear();
         }
     }
 }

--- a/src/DEX/parser/dex_encoded.cpp
+++ b/src/DEX/parser/dex_encoded.cpp
@@ -167,24 +167,19 @@ namespace KUNAI
 
             encoded_type_pair_size = KUNAI::read_sleb128(input_file);
 
+            for (size_t i = 0; i < std::abs(encoded_type_pair_size); i++)
+            {
+                type_idx = KUNAI::read_uleb128(input_file);
+
+                addr = KUNAI::read_uleb128(input_file);
+
+                encoded_type_pair = std::make_shared<EncodedTypePair>(type_idx, addr, dex_types);
+                handlers.push_back(encoded_type_pair);
+            }
+
             if (encoded_type_pair_size <= 0)
             {
                 catch_all_addr = KUNAI::read_uleb128(input_file);
-            }
-            else
-            {
-                for (size_t i = 0; i < static_cast<std::uint64_t>(encoded_type_pair_size); i++)
-                {
-                    type_idx = KUNAI::read_uleb128(input_file);
-
-                    addr = KUNAI::read_uleb128(input_file);
-
-                    if (addr > file_size)
-                        throw exceptions::OutOfBoundException("Error reading EncodedTypePair addr out of file bound");
-
-                    encoded_type_pair = std::make_shared<EncodedTypePair>(type_idx, addr, dex_types);
-                    handlers.push_back(encoded_type_pair);
-                }
             }
 
             return true;

--- a/src/DEX/parser/dex_fields.cpp
+++ b/src/DEX/parser/dex_fields.cpp
@@ -94,6 +94,8 @@ namespace KUNAI
 
         bool DexFields::parse_fields(std::ifstream &input_file)
         {
+            auto logger = LOGGER::logger();
+
             FieldID *field_id;
             auto current_offset = input_file.tellg();
             size_t i = 0;
@@ -103,29 +105,42 @@ namespace KUNAI
             // move to offset for analysis
             input_file.seekg(offset);
 
+            logger->debug("DexFields start parsing in offset {} and size {}", offset, number_of_fields);
+
             for (i = 0; i < number_of_fields; i++)
             {
                 if (!KUNAI::read_data_file<std::uint16_t>(class_idx, sizeof(std::uint16_t), input_file))
                     return false;
 
                 if (class_idx >= dex_types->get_number_of_types())
+                {
+                    logger->error("Error reading fields class_idx out of type bound ({} >= {}):", class_idx, dex_types->get_number_of_types());
                     throw exceptions::IncorrectTypeId("Error reading fields class_idx out of type bound");
+                }
 
                 if (!KUNAI::read_data_file<std::uint16_t>(type_idx, sizeof(std::uint16_t), input_file))
                     return false;
 
                 if (type_idx >= dex_types->get_number_of_types())
+                {
+                    logger->error("Error reading fields type_idx out of type bound ({} >= {})", type_idx, dex_types->get_number_of_types());
                     throw exceptions::IncorrectTypeId("Error reading fields type_idx out of type bound");
+                }
 
                 if (!KUNAI::read_data_file<std::uint32_t>(name_idx, sizeof(std::uint32_t), input_file))
                     return false;
 
                 if (name_idx >= dex_strings->get_number_of_strings())
+                {
+                    logger->error("Error reading fields name_idx out of string bound ({} >= {})", name_idx, dex_strings->get_number_of_strings());
                     throw exceptions::IncorrectStringId("Error reading fields name_idx out of string bound");
+                }
 
                 field_id = new FieldID(class_idx, type_idx, name_idx, dex_strings, dex_types);
 
                 field_ids.push_back(field_id);
+
+                logger->debug("parsed field_id number {}", i);
             }
 
             input_file.seekg(current_offset);

--- a/src/DEX/parser/dex_header.cpp
+++ b/src/DEX/parser/dex_header.cpp
@@ -6,35 +6,67 @@ namespace KUNAI
     {
         DexHeader::DexHeader(std::ifstream &input_file, std::uint64_t file_size)
         {
+            auto logger = LOGGER::logger();
+            logger->debug("DexHeader start parsing");
+
             if (!KUNAI::read_data_file<DexHeader::dexheader_t>(this->dex_struct, sizeof(DexHeader::dex_struct), input_file))
                 throw exceptions::ParserReadingException("Error reading DEX Header");
 
             if (dex_struct.link_off > file_size)
+            {
+                logger->error("Error 'link_off' out of file bound ({} > {})", dex_struct.link_off, file_size);
                 throw exceptions::OutOfBoundException("Error 'link_off' out of file bound");
+            }
 
             if (dex_struct.map_off > file_size)
+            {
+                logger->error("Error 'map_off' out of file bound ({} > {})", dex_struct.map_off, file_size);
                 throw exceptions::OutOfBoundException("Error 'map_off' out of file bound");
+            }
 
             if (dex_struct.string_ids_off > file_size)
+            {
+                logger->error("Error 'string_ids_off' out of file bound ({} > {})", dex_struct.string_ids_off, file_size);
                 throw exceptions::OutOfBoundException("Error 'string_ids_off' out of file bound");
+            }
 
             if (dex_struct.type_ids_off > file_size)
+            {
+                logger->error("Error 'type_ids_off' out of file bound ({} > {})", dex_struct.type_ids_off, file_size);
                 throw exceptions::OutOfBoundException("Error 'type_ids_off' out of file bound");
+            }
 
             if (dex_struct.proto_ids_off > file_size)
+            {
+                logger->error("Error 'proto_ids_off' out of file bound ({} > {})", dex_struct.proto_ids_off, file_size);
                 throw exceptions::OutOfBoundException("Error 'proto_ids_off' out of file bound");
+            }
 
             if (dex_struct.field_ids_off > file_size)
+            {
+                logger->error("Error 'field_ids_off' out of file bound ({} > {})", dex_struct.field_ids_off, file_size);
                 throw exceptions::OutOfBoundException("Error 'field_ids_off' out of file bound");
+            }
 
             if (dex_struct.method_ids_off > file_size)
+            {
+                logger->error("Error 'method_ids_off' out of file bound ({} > {})", dex_struct.method_ids_off, file_size);
                 throw exceptions::OutOfBoundException("Error 'method_ids_off' out of file bound");
+            }
 
             if (dex_struct.class_defs_off > file_size)
+            {
+                logger->error("Error 'class_defs_off' out of file bound ({} > {})", dex_struct.class_defs_off, file_size);
                 throw exceptions::OutOfBoundException("Error 'class_defs_off' out of file bound");
+            }
 
             if (dex_struct.data_off > file_size)
+            {
+                logger->error("Error 'data_off' out of file bound ({} > {})", dex_struct.data_off, file_size);
                 throw exceptions::OutOfBoundException("Error 'data_off' out of file bound");
+            }
+
+            logger->info("DexHeader parsing correct");
         }
 
         std::ostream &operator<<(std::ostream &os, const DexHeader &entry)

--- a/src/DEX/parser/dex_parser.cpp
+++ b/src/DEX/parser/dex_parser.cpp
@@ -10,6 +10,10 @@ namespace KUNAI
 
         void DexParser::parse_dex_file(std::ifstream &input_file, std::uint64_t file_size)
         {
+            auto logger = LOGGER::logger();
+
+            logger->info("DexParser start parsing dex file with a size of {} bytes", file_size);
+
             std::uint8_t header[8];
 
             if (file_size < sizeof(DexHeader::dexheader_t))
@@ -28,6 +32,10 @@ namespace KUNAI
 
             input_file.seekg(0);
 
+            logger->debug("Checks correct");
+
+            logger->info("Starting DEX headers parsing");
+
             dex_header = std::make_shared<DexHeader>(input_file, file_size);
             dex_strings = std::make_shared<DexStrings>(input_file, file_size, dex_header->get_dex_header().string_ids_size, dex_header->get_dex_header().string_ids_off);
             dex_types = std::make_shared<DexTypes>(input_file, dex_header->get_dex_header().type_ids_size, dex_header->get_dex_header().type_ids_off, dex_strings);
@@ -35,6 +43,8 @@ namespace KUNAI
             dex_fields = std::make_shared<DexFields>(input_file, dex_header->get_dex_header().field_ids_size, dex_header->get_dex_header().field_ids_off, dex_strings, dex_types);
             dex_methods = std::make_shared<DexMethods>(input_file, dex_header->get_dex_header().method_ids_size, dex_header->get_dex_header().method_ids_off, dex_strings, dex_types, dex_protos);
             dex_classes = std::make_shared<DexClasses>(input_file, file_size, dex_header->get_dex_header().class_defs_size, dex_header->get_dex_header().class_defs_off, dex_strings, dex_types, dex_fields, dex_methods);
+        
+            logger->info("Finished DEX headers parsing");
         }
 
         std::uint32_t DexParser::get_header_version()

--- a/src/Utils/utils.cpp
+++ b/src/Utils/utils.cpp
@@ -60,29 +60,30 @@ std::uint64_t read_uleb128(std::istream& input_file)
 {
     std::uint64_t value = 0;
     unsigned shift = 0;
-    std::uint8_t byte_read;
+    std::uint8_t byte_read, current;
+    
     do
     {
         read_data_file<std::uint8_t>(byte_read, sizeof(std::uint8_t), input_file);
-        value += static_cast<std::uint64_t>(byte_read & 0x7f) << shift;
+        value |= static_cast<std::uint64_t>(byte_read & 0x7f) << shift;
         shift += 7;
-    } while (byte_read >= 128);
+    } while (byte_read & 0x80);
     
     return value;
 }
 
-std::uint64_t read_sleb128(std::istream& input_file)
+std::int64_t read_sleb128(std::istream& input_file)
 {
-    std::uint64_t value = 0;
+    std::int64_t value = 0;
     unsigned shift = 0;
     std::uint8_t byte_read;
     do
     {
         read_data_file<std::uint8_t>(byte_read, sizeof(std::uint8_t), input_file);
-        value += static_cast<std::uint64_t>(byte_read & 0x7f) << shift;
+        value |= static_cast<std::uint64_t>(byte_read & 0x7f) << shift;
         shift += 7;
-    } while (byte_read >= 128);
-    
+    } while (byte_read & 0x80);
+    // sign extend negative numbers
     if ((byte_read & 0x40) != 0)
         value |= static_cast<int64_t>(-1) << shift;
 

--- a/src/Utils/utils.cpp
+++ b/src/Utils/utils.cpp
@@ -37,14 +37,15 @@ std::string read_dex_string(std::istream& input_file, std::uint64_t offset)
     std::uint64_t current_offset = input_file.tellg();
     std::string new_str;
     std::uint8_t character = -1;
-    std::uint8_t count;
+    std::uint64_t utf16_size;
 
     // set offset of file in at the
     // given offset
     input_file.seekg(offset);
-    input_file.read(reinterpret_cast<char*>(&count), sizeof(std::uint8_t));
 
-    while(count-- != 0)
+    utf16_size = read_uleb128(input_file);
+
+    while(utf16_size-- != 0)
     {
         input_file.read(reinterpret_cast<char*>(&character), sizeof(std::uint8_t));
         new_str += character;

--- a/src/includes/KUNAI/DEX/parser/dex_encoded.hpp
+++ b/src/includes/KUNAI/DEX/parser/dex_encoded.hpp
@@ -25,7 +25,8 @@ namespace KUNAI
 {
     namespace DEX
     {
-
+        class EncodedAnnotation;
+        
         class EncodedValue
         {
         public:
@@ -42,9 +43,15 @@ namespace KUNAI
                 return array;
             }
 
+            std::shared_ptr<EncodedAnnotation> get_annotation()
+            {
+                return annotation;
+            }
+
         private:
             std::vector<std::uint8_t> values;
             std::vector<std::shared_ptr<EncodedValue>> array;
+            std::shared_ptr<EncodedAnnotation> annotation;
         };
 
         class EncodedArray
@@ -314,6 +321,51 @@ namespace KUNAI
             std::shared_ptr<CodeItemStruct> code_item;
         };
 
+        class AnnotationElement
+        {
+        public:
+            AnnotationElement(std::ifstream& input_file);
+            ~AnnotationElement() = default;
+
+            std::uint64_t get_name_idx()
+            {
+                return name_idx;
+            }
+
+            std::shared_ptr<EncodedValue> get_value()
+            {
+                return value;
+            }
+        private:
+            std::uint64_t name_idx;
+            std::shared_ptr<EncodedValue> value;
+        };
+
+        class EncodedAnnotation
+        {
+        public:
+            EncodedAnnotation(std::ifstream& input_file);
+            ~EncodedAnnotation();
+
+            std::uint64_t get_type_idx()
+            {
+                return type_idx;
+            }
+
+            std::uint64_t get_number_of_elements()
+            {
+                return size;
+            }
+
+            const std::vector<std::shared_ptr<AnnotationElement>>& get_elements() const
+            {
+                return elements;
+            }
+        private:
+            std::uint64_t type_idx;
+            std::uint64_t size;
+            std::vector<std::shared_ptr<AnnotationElement>> elements;
+        };
     }
 }
 

--- a/src/includes/KUNAI/Utils/utils.hpp
+++ b/src/includes/KUNAI/Utils/utils.hpp
@@ -4,8 +4,60 @@
 #define UTILS_HPP
 
 #include <iostream>
+#include <spdlog/spdlog.h>
+#include <spdlog/sinks/basic_file_sink.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
 
 namespace KUNAI {
+
+    namespace LOGGER {
+        enum logger_output_t {
+            TO_CONSOLE = 0,
+            TO_STDERR = 1,
+            TO_FILE = 2
+        };
+
+        logger_output_t static global_logger_output = TO_STDERR;
+        static std::string log_file_name = "";
+
+        inline std::shared_ptr<spdlog::logger> logger()
+        {
+            switch (global_logger_output)
+            {
+            case TO_CONSOLE:
+            {
+                auto console_logger = spdlog::get("console");
+                if (console_logger == nullptr)
+                    return spdlog::stdout_color_mt("console");
+                else
+                    return console_logger;
+            }
+                break;
+            case TO_STDERR:
+            {
+                auto error_logger = spdlog::get("stderr");
+                if (error_logger == nullptr)
+                    return spdlog::stderr_color_mt("stderr");
+                else
+                    return error_logger;
+            }
+                break;
+            case TO_FILE:
+            {
+                auto file_logger = spdlog::get("file_logger");
+                if (file_logger == nullptr)
+                    return spdlog::basic_logger_mt("file_logger", log_file_name);
+                else
+                    return file_logger;
+            }
+                break;
+            default:
+                break;
+            }
+
+            return nullptr;
+        }
+    }
 
     const std::uint32_t MAX_ANSII_STR_SIZE = 256;
 

--- a/src/includes/KUNAI/Utils/utils.hpp
+++ b/src/includes/KUNAI/Utils/utils.hpp
@@ -34,7 +34,7 @@ namespace KUNAI {
     std::string read_ansii_string(std::istream& input_file, std::uint64_t offset);
     std::string read_dex_string(std::istream& input_file, std::uint64_t offset);
     std::uint64_t read_uleb128(std::istream& input_file);
-    std::uint64_t read_sleb128(std::istream& input_file);
+    std::int64_t read_sleb128(std::istream& input_file);
 }
 
 #endif

--- a/src/mjolnIR/Lifters/lifter_android.cpp
+++ b/src/mjolnIR/Lifters/lifter_android.cpp
@@ -1010,8 +1010,25 @@ namespace KUNAI
                 // as it is a call to a method, we can safely retrieve the operand as method
                 auto method_called = call_inst->get_operands_kind_method();
 
+                // Get the values for the Callee
+
                 std::string method_name = *method_called->get_method_name();
-                std::string class_name = reinterpret_cast<DEX::Class *>(method_called->get_method_class())->get_name();
+
+                std::string class_name = "";
+                auto type = method_called->get_method_class();
+                if (type->get_type() == type->ARRAY)
+                {
+                    auto array_type = reinterpret_cast<DEX::Array *>(type);
+
+                    class_name = array_type->get_raw();
+                }
+                else if (type->get_type() == type->CLASS)
+                {
+                    auto class_type = reinterpret_cast<DEX::Class *>(type);
+
+                    class_name = class_type->get_name();
+                }
+
                 std::string proto = method_called->get_method_prototype()->get_proto_str();
 
                 if (this->android_analysis)

--- a/src/tests-src/test_dex_disassembler.cpp
+++ b/src/tests-src/test_dex_disassembler.cpp
@@ -28,6 +28,9 @@ main(int argc, char**argv)
     fsize = dex_file.tellg() - fsize;
     dex_file.seekg(0);
 
+    // Set the logging level in spdlog, we set to debug
+    spdlog::set_level(spdlog::level::debug);
+
     // get a unique_ptr from a DEX object.
     // this will parse the DEX file, and nothing more.
     auto dex = KUNAI::DEX::get_unique_dex_object(dex_file, fsize);

--- a/src/tests-src/test_dex_parser.cpp
+++ b/src/tests-src/test_dex_parser.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <memory>
 
+#include <spdlog/spdlog.h>
 // necessary to work with dex import the main DEX object
 #include "dex.hpp"
 
@@ -33,6 +34,9 @@ int main(int argc, char **argv)
      * object will just parse the file, it will not disassembly neither
      * will analyze the DEX, that's something you can decide to do.
      */
+
+    // Set the logging level in spdlog, we set to debug
+    spdlog::set_level(spdlog::level::debug);
 
     // `DEX' class is inside of namespace `DEX' inside of namespace `KUNAI'
     // you have a couple of methods in KUNAI::DEX one to return a dex unique_ptr

--- a/src/tests-src/test_dex_parser.cpp
+++ b/src/tests-src/test_dex_parser.cpp
@@ -92,6 +92,8 @@ int main(int argc, char **argv)
     
     for (auto class_def : class_defs)
     {
+        if (class_def->get_class_idx() == nullptr)
+            continue;
         std::cout << "\tClass name: " << class_def->get_class_idx()->get_name() << std::endl;
         std::cout << "\tSource file name: ";
         if (class_def->get_source_file_idx())

--- a/src/tests-src/test_ir.cpp
+++ b/src/tests-src/test_ir.cpp
@@ -1,87 +1,88 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <cassert>
 
 #include "ir_grammar.hpp"
-
+#include "utils.hpp"
 
 int
 main()
 {
+    auto logger = KUNAI::LOGGER::logger();
+    // Set the logging level in spdlog, we set to debug
+    spdlog::set_level(spdlog::level::debug);
+
     int number_of_test_passed = 0;
 
-    std::string any_str = "dorime";
+    std::string any_str = "test_passed";
     auto callee = std::make_shared<KUNAI::MJOLNIR::IRCallee>(0xA, any_str, any_str, 2, any_str, any_str, 0);
     auto callee2 = std::make_shared<KUNAI::MJOLNIR::IRCallee>(0xA, any_str, any_str, 2, any_str, any_str, 0);
 
-    if (callee->equal(callee2))
-    {
-        number_of_test_passed++;
-        std::cout << callee->to_string() << std::endl;
-    }
+    logger->debug("Checking two callee objects");
+    assert(callee->equal(callee2));
+    number_of_test_passed++;
+    logger->debug(callee->to_string());
+
 
     auto class1 = std::make_shared<KUNAI::MJOLNIR::IRClass>(any_str, any_str, 0);
     auto class2 = std::make_shared<KUNAI::MJOLNIR::IRClass>(any_str, any_str, 0);
 
-    if (class1->equal(class2))
-    {
-        number_of_test_passed++;
-        std::cout << class1->to_string() << std::endl;
-    }
+    logger->debug("Checking two classes");
+    assert(class1->equal(class2));
+    number_of_test_passed++;
+    logger->debug(class1->to_string());
+
 
     auto str1 = std::make_shared<KUNAI::MJOLNIR::IRString>(any_str, any_str, 0);
     auto str2 = std::make_shared<KUNAI::MJOLNIR::IRString>(any_str, any_str, 0);
     
-    if (str1->equal(str2))
-    {
-        number_of_test_passed++;
-        std::cout << str1->to_string() << std::endl;
-    }
+    logger->debug("Checking two strings");
+    assert(str1->equal(str2));
+    number_of_test_passed++;
+    logger->debug(str1->to_string());
 
     auto mem1 = std::make_shared<KUNAI::MJOLNIR::IRMemory>(0x0, 0x0, KUNAI::MJOLNIR::IRMemory::LE_ACCESS, any_str, 0);
     auto mem2 = std::make_shared<KUNAI::MJOLNIR::IRMemory>(0x0, 0x0, KUNAI::MJOLNIR::IRMemory::LE_ACCESS, any_str, 0);
     
-    if (mem2->equal(mem1))
-    {
-        number_of_test_passed++;
-        std::cout << mem1->to_string() << std::endl;
-    }
+    logger->debug("Checking two memory addresses");
+    assert(mem2->equal(mem1));
+    number_of_test_passed++;
+    logger->debug(mem1->to_string());
 
     auto const_int1 = std::make_shared<KUNAI::MJOLNIR::IRConstInt>(0x0, true, KUNAI::MJOLNIR::IRConstInt::LE_ACCESS, any_str, 0);
     auto const_int2 = std::make_shared<KUNAI::MJOLNIR::IRConstInt>(0x0, true, KUNAI::MJOLNIR::IRConstInt::LE_ACCESS, any_str, 0);
 
-    if (const_int1->equal(const_int2))
-    {
-        number_of_test_passed++;
-        std::cout << const_int1->to_string() << std::endl;
-    }
+    logger->debug("Checking two const ints");
+    assert(const_int1->equal(const_int2));
+    number_of_test_passed++;
+    logger->debug(const_int1->to_string());
+
 
     auto temp_reg1 = std::make_shared<KUNAI::MJOLNIR::IRTempReg>(0x0, any_str, 0);
     auto temp_reg2 = std::make_shared<KUNAI::MJOLNIR::IRTempReg>(0x0, any_str, 0);
 
-    if (temp_reg1->equal(temp_reg2))
-    {
-        number_of_test_passed++;
-        std::cout << temp_reg1->to_string() << std::endl;
-    }
+    logger->debug("Checking temporary registers");
+    assert(temp_reg1->equal(temp_reg2));
+    number_of_test_passed++;
+    logger->debug(temp_reg1->to_string());
 
     auto reg1 = std::make_shared<KUNAI::MJOLNIR::IRReg>(0x0, KUNAI::MJOLNIR::x86_arch, any_str, 0);
     auto reg2 = std::make_shared<KUNAI::MJOLNIR::IRReg>(0x0, KUNAI::MJOLNIR::x86_arch, any_str, 0);
 
-    if (reg1->equal(reg2))
-    {
-        number_of_test_passed++;
-        std::cout << reg1->to_string() << std::endl;
-    }
+    logger->debug("Checking registers");
+    assert(reg1->equal(reg2));
+    number_of_test_passed++;
+    logger->debug(reg1->to_string());
 
     std::shared_ptr<KUNAI::MJOLNIR::IRType> type1 = std::make_shared<KUNAI::MJOLNIR::IRReg>(0x0, KUNAI::MJOLNIR::dalvik_arch, any_str, 0);
     std::shared_ptr<KUNAI::MJOLNIR::IRType> type2 = std::make_shared<KUNAI::MJOLNIR::IRTempReg>(0x0, any_str, 0);
 
-    if (!type1->equal(type2))
-    {
-        number_of_test_passed++;
-        std::cout << "Dorime" << std::endl;
-    }
+    logger->debug("Checking two types are different");
+    assert(!type1->equal(type2));
+    number_of_test_passed++;
+    logger->debug(type1->to_string());
+    logger->debug(type2->to_string());
 
-    return number_of_test_passed;
+    return (number_of_test_passed == 8) ? 0 : 1;
 }


### PR DESCRIPTION
Added logging using library **libspdlog**, added code in utility to get logger and write in cerr, cout or in a file: https://github.com/Fare9/KUNAI-static-analyzer/commit/ac0a0e18cebaf3f12403e871d096c85117e0b19a. Added a little installation/compilation script, for the moment just for debian based systems: https://github.com/Fare9/KUNAI-static-analyzer/commit/628594a177df79c37422c7fe5d96d38cf2d73dac. Added asserts to tests: https://github.com/Fare9/KUNAI-static-analyzer/commit/383a0bfef4c761335d6fef30e672e1447f016761.

Also fixed a couple of bugs, one of them in a for loop with an incorrect check: https://github.com/Fare9/KUNAI-static-analyzer/commit/b8e735dc68c1203d2d231f0501efaa1e95a6dc35. The other bug was a big bug with an incorrect read of *DEX Strings*, KUNAI was using *std::uint8_t* instead of *std::uint64_t*, and only one byte was read for string size instead of a *read_uleb128*: https://github.com/Fare9/KUNAI-static-analyzer/commit/86718dcb5d1d6b12b209b418cc72b9d6311df438.