### PR TITLE
Fix CMake >=3.20 warning on policy CMP0115

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
+cmake_policy(SET CMP0115 NEW)
 
 # Project name for KUNAI
 project(

--- a/src/DEX/Analysis/CMakeLists.txt
+++ b/src/DEX/Analysis/CMakeLists.txt
@@ -5,7 +5,7 @@ ${CMAKE_CURRENT_LIST_DIR}/dex_dvm_basic_block.cpp
 ${CMAKE_CURRENT_LIST_DIR}/dex_exception_analysis.cpp
 ${CMAKE_CURRENT_LIST_DIR}/dex_field_analysis.cpp
 ${CMAKE_CURRENT_LIST_DIR}/dex_method_analysis.cpp
-${CMAKE_CURRENT_LIST_DIR}/dex_string_analysis
+${CMAKE_CURRENT_LIST_DIR}/dex_string_analysis.cpp
 )
 
 set(KUNAI_DEX_ANALYSIS_INC_FILES


### PR DESCRIPTION
Fix CMake >=3.20 complaining about no value set for policy [CMP0115](https://cmake.org/cmake/help/latest/policy/CMP0115.html).

Prior to CMake 3.20, if a source file has no file extension, CMake probes by appending a list of known extensions.  The preferred behavior now is to have explicit extensions; the old behavior, as in other policies, is deprecated and may be removed in future CMake versions.