### PR TITLE
Add const qualifier to variables that could use it

### DIFF
--- a/src/APK/apk.cpp
+++ b/src/APK/apk.cpp
@@ -42,7 +42,7 @@ namespace KUNAI
             for (int i = 0, n = zip_entries_total(zip); i < n; i++)
             {
                 zip_entry_openbyindex(zip, i);
-                std::string file_name = zip_entry_name(zip);
+                std::string const file_name = zip_entry_name(zip);
 
                 // in case it contains .dex, work with it
                 if (file_name.find(".dex") != std::string::npos && file_name.find("classes") != std::string::npos)

--- a/src/DEX/Analysis/dex_analysis.cpp
+++ b/src/DEX/Analysis/dex_analysis.cpp
@@ -177,7 +177,7 @@ namespace KUNAI
 
         MethodAnalysis* Analysis::get_method_analysis_by_name(std::string& class_name, std::string& method_name, std::string& method_descriptor)
         {
-            std::string m_hash = class_name+method_name+method_descriptor;
+            std::string const m_hash = class_name+method_name+method_descriptor;
 
             if (method_hashes.find(m_hash) == method_hashes.end())
                 return nullptr;
@@ -233,7 +233,7 @@ namespace KUNAI
         std::vector<ClassAnalysis*> Analysis::find_classes(std::string name = ".*", bool no_external = false)
         {
             std::vector<ClassAnalysis*> classes_vector;
-            std::regex class_name_regex(name);
+            std::regex const class_name_regex(name);
 
             for (auto & c : classes)
             {
@@ -284,7 +284,7 @@ namespace KUNAI
         std::vector<StringAnalysis*> Analysis::find_strings(std::string string = ".*")
         {
             std::vector<StringAnalysis*> strings_list;
-            std::regex str_reg(string);
+            std::regex const str_reg(string);
 
             for (auto it = strings.begin(); it != strings.end(); it++)
             {
@@ -561,9 +561,9 @@ namespace KUNAI
 
         MethodAnalysis* Analysis::_resolve_method(std::string class_name, std::string method_name, std::string method_descriptor)
         {
-            std::string m_hash = class_name+method_name+method_descriptor;
+            std::string const m_hash = class_name+method_name+method_descriptor;
             
-            std::map<std::uint64_t, Instruction*> empty_instructions;
+            std::map<std::uint64_t, Instruction*> const empty_instructions;
 
             if (method_hashes.find(m_hash) == method_hashes.end())
             {

--- a/src/DEX/Analysis/dex_class_analysis.cpp
+++ b/src/DEX/Analysis/dex_class_analysis.cpp
@@ -65,7 +65,7 @@ namespace KUNAI
             if (!is_external)
                 return false;
 
-            std::string class_name = this->name();
+            std::string const class_name = this->name();
 
             for (auto known_api : known_apis)
             {

--- a/src/DEX/Analysis/dex_dvm_basic_block.cpp
+++ b/src/DEX/Analysis/dex_dvm_basic_block.cpp
@@ -99,11 +99,11 @@ namespace KUNAI
         void DVMBasicBlock::push(Instruction* instr)
         {
             nb_instructions += 1;
-            std::uint64_t idx = end;
+            std::uint64_t const idx = end;
             last_length = instr->get_length();
             end += last_length;
 
-            std::uint32_t op_value = instr->get_OP();
+            std::uint32_t const op_value = instr->get_OP();
 
             if ((op_value == DVMTypes::Opcode::OP_FILL_ARRAY_DATA) ||
                 (op_value == DVMTypes::Opcode::OP_PACKED_SWITCH) ||

--- a/src/DEX/Analysis/dex_method_analysis.cpp
+++ b/src/DEX/Analysis/dex_method_analysis.cpp
@@ -24,7 +24,7 @@ namespace KUNAI
             if (!is_external)
                 return false;
 
-            std::string class_name = this->class_name();
+            std::string const class_name = this->class_name();
 
             for (const auto &known_api : known_apis)
             {

--- a/src/DEX/DVM/dex_dalvik_opcodes.cpp
+++ b/src/DEX/DVM/dex_dalvik_opcodes.cpp
@@ -34,7 +34,7 @@ namespace KUNAI
 
         std::string &DalvikOpcodes::get_instruction_type_str(std::uint32_t instruction)
         {
-            DVMTypes::Kind kind = get_instruction_type(instruction);
+            DVMTypes::Kind const kind = get_instruction_type(instruction);
 
             return KindString[kind];
         }
@@ -69,7 +69,7 @@ namespace KUNAI
 
             method += "(";
 
-            size_t n_params = dex_parser->get_methods()->get_method_by_order(id)->get_method_prototype()->get_number_of_parameters();
+            size_t const n_params = dex_parser->get_methods()->get_method_by_order(id)->get_method_prototype()->get_number_of_parameters();
 
             for (size_t i = 0; i < n_params; i++)
             {
@@ -90,7 +90,7 @@ namespace KUNAI
         {
             std::string proto;
 
-            size_t n_params = dex_parser->get_protos()->get_proto_by_order(id)->get_number_of_parameters();
+            size_t const n_params = dex_parser->get_protos()->get_proto_by_order(id)->get_number_of_parameters();
 
             proto = "(";
 

--- a/src/DEX/DVM/dex_disassembler.cpp
+++ b/src/DEX/DVM/dex_disassembler.cpp
@@ -146,7 +146,7 @@ namespace KUNAI
         std::map<std::uint64_t, Instruction*> DexDisassembler::get_instructions_by_class_and_method(ClassDef* class_def, EncodedMethod* encoded_method)
         {
             std::map<std::uint64_t, Instruction*> instructions;
-            std::tuple<ClassDef*, EncodedMethod*> key = std::make_tuple(class_def, encoded_method);
+            std::tuple<ClassDef*, EncodedMethod*> const key = std::make_tuple(class_def, encoded_method);
             if (method_instructions.find(key) != method_instructions.end())
             {
                 auto & instrs = method_instructions[key];

--- a/src/DEX/DVM/dex_instructions.cpp
+++ b/src/DEX/DVM/dex_instructions.cpp
@@ -1109,8 +1109,8 @@ namespace KUNAI
         std::string Instruction45cc::get_output()
         {
             std::string output = "";
-            std::string method = get_dalvik_opcodes()->get_dalvik_method_by_id_str(method_reference);
-            std::string prototype = get_dalvik_opcodes()->get_dalvik_proto_by_id_str(proto_reference);
+            std::string const method = get_dalvik_opcodes()->get_dalvik_method_by_id_str(method_reference);
+            std::string const prototype = get_dalvik_opcodes()->get_dalvik_proto_by_id_str(proto_reference);
 
             for (size_t i = 0; i < reg_count; i++)
                 output += this->get_register_correct_representation(registers[i]) + ", ";
@@ -1167,8 +1167,8 @@ namespace KUNAI
         std::string Instruction4rcc::get_output()
         {
             std::string output = "";
-            std::string method = get_dalvik_opcodes()->get_dalvik_method_by_id_str(method_reference);
-            std::string prototype = get_dalvik_opcodes()->get_dalvik_proto_by_id_str(proto_reference);
+            std::string const method = get_dalvik_opcodes()->get_dalvik_method_by_id_str(method_reference);
+            std::string const prototype = get_dalvik_opcodes()->get_dalvik_proto_by_id_str(proto_reference);
 
             for (size_t i = 0; i < reg_count; i++)
                 output = this->get_register_correct_representation(registers[i]) + ", ";
@@ -1909,7 +1909,7 @@ namespace KUNAI
                 instruction = std::make_unique<Instruction21c>(dalvik_opcodes, input_file); // 'const-method-type' # Dalvik 039
                 break;
             default:
-                std::string msg = "Invalid Instruction '" + std::to_string(opcode) + "'";
+                std::string const msg = "Invalid Instruction '" + std::to_string(opcode) + "'";
                 throw exceptions::InvalidInstruction(msg, 1);
             }
 

--- a/src/DEX/DVM/dex_linear_sweep_disassembly.cpp
+++ b/src/DEX/DVM/dex_linear_sweep_disassembly.cpp
@@ -13,7 +13,7 @@ namespace KUNAI {
             std::map<std::uint64_t, instruction_t> instructions;
             std::uint64_t instruction_index = 0;
             instruction_t instruction;
-            size_t buffer_size = byte_buffer.size();
+            size_t const buffer_size = byte_buffer.size();
             std::uint32_t opcode;
             bool exist_switch = false;
 

--- a/src/DEX/DVM/dex_recursive_traversal_disassembly.cpp
+++ b/src/DEX/DVM/dex_recursive_traversal_disassembly.cpp
@@ -15,9 +15,9 @@ namespace KUNAI
             std::map<std::uint64_t, bool> seen;
             std::uint64_t instruction_index;
             instruction_t instruction;
-            size_t buffer_size = byte_buffer.size();
+            size_t const buffer_size = byte_buffer.size();
             std::uint32_t opcode;
-            bool exist_switch = false;
+            bool const exist_switch = false;
             std::stringstream input_buffer;
 
             auto exceptions = determine_exception(dalvik_opcodes, method);

--- a/src/DEX/parser/dex_encoded.cpp
+++ b/src/DEX/parser/dex_encoded.cpp
@@ -40,7 +40,7 @@ namespace KUNAI
             }
             case DVMTypes::VALUE_ARRAY:
             {
-                std::uint64_t size = KUNAI::read_uleb128(input_file);
+                std::uint64_t const size = KUNAI::read_uleb128(input_file);
                 encodedvalue_t aux;
                 for (size_t i = 0; i < size; i++)
                 {

--- a/src/Utils/utils.cpp
+++ b/src/Utils/utils.cpp
@@ -4,7 +4,7 @@ namespace KUNAI {
 
 std::string read_ansii_string(std::istream& input_file, std::uint64_t offset)
 {
-    std::uint64_t current_offset = input_file.tellg();
+    std::uint64_t const current_offset = input_file.tellg();
     std::string new_str;
     std::uint8_t character = -1;
 
@@ -33,7 +33,7 @@ std::string read_ansii_string(std::istream& input_file, std::uint64_t offset)
 
 std::string read_dex_string(std::istream& input_file, std::uint64_t offset)
 {
-    std::uint64_t current_offset = input_file.tellg();
+    std::uint64_t const current_offset = input_file.tellg();
     std::string new_str;
     std::uint8_t character = -1;
     std::uint64_t utf16_size;

--- a/src/mjolnIR/Analysis/single_block_optimizations.cpp
+++ b/src/mjolnIR/Analysis/single_block_optimizations.cpp
@@ -54,7 +54,7 @@ namespace KUNAI
                         if (first_instr->get_op1()->equals(first_instr->get_op2()) &&
                             second_instr->get_op1()->equals(first_instr->get_result()))
                         {
-                            irassign_t assign_inst = std::make_shared<IRAssign>(second_instr->get_result(), second_instr->get_op2());
+                            irassign_t const assign_inst = std::make_shared<IRAssign>(second_instr->get_result(), second_instr->get_op2());
                             new_statements.push_back(assign_inst);
                             i += 2;
                             modified = true;
@@ -74,7 +74,7 @@ namespace KUNAI
 
                         if (first_instr->get_op1()->equals(second_instr->get_op2()) && first_instr->get_result()->equals(second_instr->get_op1()))
                         {
-                            irassign_t assign_inst = std::make_shared<IRAssign>(second_instr->get_result(), first_instr->get_op2());
+                            irassign_t const assign_inst = std::make_shared<IRAssign>(second_instr->get_result(), first_instr->get_op2());
                             new_statements.push_back(assign_inst);
                             i += 2;
                             modified = true;
@@ -93,7 +93,7 @@ namespace KUNAI
                         if (first_instr->get_op2()->equals(second_instr->get_op2()) 
                             && first_instr->get_result()->equals(second_instr->get_op1()))
                         {
-                            irassign_t assign_inst = std::make_shared<IRAssign>(second_instr->get_result(), first_instr->get_op1());
+                            irassign_t const assign_inst = std::make_shared<IRAssign>(second_instr->get_result(), first_instr->get_op1());
                             new_statements.push_back(assign_inst);
                             i += 2;
                             modified = true;
@@ -161,7 +161,7 @@ namespace KUNAI
 
                             auto result = std::make_shared<IRConstInt>(*int1 + *int2);
 
-                            irbinop_t bin_op = std::make_shared<IRBinOp>(IRBinOp::ADD_OP_T, op2->get_result(), op1->get_op1(), result);
+                            irbinop_t const bin_op = std::make_shared<IRBinOp>(IRBinOp::ADD_OP_T, op2->get_result(), op1->get_op1(), result);
                             new_statements.push_back(bin_op);
                             i += 2;
                             modified = true;
@@ -202,7 +202,7 @@ namespace KUNAI
                             auto new_temporal = graph->get_last_temporal() + 1;
                             graph->set_last_temporal(new_temporal);
                             
-                            std::string temp_name = "t" + new_temporal;
+                            std::string const temp_name = "t" + new_temporal;
 
                             auto temp_reg = std::make_shared<IRTempReg>(new_temporal,temp_name, 4);
 

--- a/src/mjolnIR/Analysis/single_instruction_optimizations.cpp
+++ b/src/mjolnIR/Analysis/single_instruction_optimizations.cpp
@@ -28,14 +28,14 @@ namespace KUNAI
                     {
                     case IRBinOp::ADD_OP_T:
                     {
-                        irconstint_t const_int = std::make_shared<IRConstInt>(*op1_int + *op2_int);
+                        irconstint_t const const_int = std::make_shared<IRConstInt>(*op1_int + *op2_int);
 
                         assign = std::make_shared<IRAssign>(dest, const_int);
                         break;
                     }
                     case IRBinOp::SUB_OP_T:
                     {
-                        irconstint_t const_int = std::make_shared<IRConstInt>(*op1_int - *op2_int);
+                        irconstint_t const const_int = std::make_shared<IRConstInt>(*op1_int - *op2_int);
 
                         assign = std::make_shared<IRAssign>(dest, const_int);
                         break;
@@ -43,7 +43,7 @@ namespace KUNAI
                     case IRBinOp::S_MUL_OP_T:
                     case IRBinOp::U_MUL_OP_T:
                     {
-                        irconstint_t const_int = std::make_shared<IRConstInt>(*op1_int * *op2_int);
+                        irconstint_t const const_int = std::make_shared<IRConstInt>(*op1_int * *op2_int);
 
                         assign = std::make_shared<IRAssign>(dest, const_int);
                         break;
@@ -51,42 +51,42 @@ namespace KUNAI
                     case IRBinOp::S_DIV_OP_T:
                     case IRBinOp::U_DIV_OP_T:
                     {
-                        irconstint_t const_int = std::make_shared<IRConstInt>(*op1_int / *op2_int);
+                        irconstint_t const const_int = std::make_shared<IRConstInt>(*op1_int / *op2_int);
 
                         assign = std::make_shared<IRAssign>(dest, const_int);
                         break;
                     }
                     case IRBinOp::MOD_OP_T:
                     {
-                        irconstint_t const_int = std::make_shared<IRConstInt>(*op1_int % *op2_int);
+                        irconstint_t const const_int = std::make_shared<IRConstInt>(*op1_int % *op2_int);
 
                         assign = std::make_shared<IRAssign>(dest, const_int);
                         break;
                     }
                     case IRBinOp::AND_OP_T:
                     {
-                        irconstint_t const_int = std::make_shared<IRConstInt>(*op1_int & *op2_int);
+                        irconstint_t const const_int = std::make_shared<IRConstInt>(*op1_int & *op2_int);
 
                         assign = std::make_shared<IRAssign>(dest, const_int);
                         break;
                     }
                     case IRBinOp::OR_OP_T:
                     {
-                        irconstint_t const_int = std::make_shared<IRConstInt>(*op1_int | *op2_int);
+                        irconstint_t const const_int = std::make_shared<IRConstInt>(*op1_int | *op2_int);
 
                         assign = std::make_shared<IRAssign>(dest, const_int);
                         break;
                     }
                     case IRBinOp::XOR_OP_T:
                     {
-                        irconstint_t const_int = std::make_shared<IRConstInt>(*op1_int ^ *op2_int);
+                        irconstint_t const const_int = std::make_shared<IRConstInt>(*op1_int ^ *op2_int);
 
                         assign = std::make_shared<IRAssign>(dest, const_int);
                         break;
                     }
                     case IRBinOp::SHL_OP_T:
                     {
-                        irconstint_t const_int = std::make_shared<IRConstInt>(*op1_int << *op2_int);
+                        irconstint_t const const_int = std::make_shared<IRConstInt>(*op1_int << *op2_int);
 
                         assign = std::make_shared<IRAssign>(dest, const_int);
                         break;
@@ -94,7 +94,7 @@ namespace KUNAI
                     case IRBinOp::SHR_OP_T:
                     case IRBinOp::USHR_OP_T:
                     {
-                        irconstint_t const_int = std::make_shared<IRConstInt>(*op1_int >> *op2_int);
+                        irconstint_t const const_int = std::make_shared<IRConstInt>(*op1_int >> *op2_int);
 
                         assign = std::make_shared<IRAssign>(dest, const_int);
                         break;
@@ -173,25 +173,25 @@ namespace KUNAI
                 {
                 case IRUnaryOp::INC_OP_T:
                 {
-                    irconstint_t const_int = std::make_shared<IRConstInt>((*op1_int)++);
+                    irconstint_t const const_int = std::make_shared<IRConstInt>((*op1_int)++);
                     assign = std::make_shared<IRAssign>(dest, const_int);
                     break;
                 }
                 case IRUnaryOp::DEC_OP_T:
                 {
-                    irconstint_t const_int = std::make_shared<IRConstInt>((*op1_int)--);
+                    irconstint_t const const_int = std::make_shared<IRConstInt>((*op1_int)--);
                     assign = std::make_shared<IRAssign>(dest, const_int);
                     break;
                 }
                 case IRUnaryOp::NOT_OP_T:
                 {
-                    irconstint_t const_int = std::make_shared<IRConstInt>(!(*op1_int));
+                    irconstint_t const const_int = std::make_shared<IRConstInt>(!(*op1_int));
                     assign = std::make_shared<IRAssign>(dest, const_int);
                     break;
                 }
                 case IRUnaryOp::NEG_OP_T:
                 {
-                    irconstint_t const_int = std::make_shared<IRConstInt>(~(*op1_int));
+                    irconstint_t const const_int = std::make_shared<IRConstInt>(~(*op1_int));
                     assign = std::make_shared<IRAssign>(dest, const_int);
                     break;
                 }

--- a/src/mjolnIR/Lifters/lifter_android.cpp
+++ b/src/mjolnIR/Lifters/lifter_android.cpp
@@ -16,7 +16,7 @@ namespace KUNAI
         MJOLNIR::irgraph_t LifterAndroid::lift_android_method(DEX::MethodAnalysis* method_analysis, DEX::Analysis* android_analysis)
         {
             auto & bbs = method_analysis->get_basic_blocks()->get_basic_blocks();
-            size_t n_bbs = bbs.size();
+            size_t const n_bbs = bbs.size();
             // set android_analysis
             this->android_analysis = android_analysis;
             // graph returnedd by
@@ -124,7 +124,7 @@ namespace KUNAI
             {
             case DEX::DVMTypes::Opcode::OP_NOP:
             {
-                MJOLNIR::irstmnt_t nop = std::make_shared<MJOLNIR::IRNop>();
+                MJOLNIR::irstmnt_t const nop = std::make_shared<MJOLNIR::IRNop>();
                 bb->append_statement_to_block(nop);
                 break;
             }
@@ -1128,7 +1128,7 @@ namespace KUNAI
                 auto call_inst = reinterpret_cast<DEX::Instruction35c*>(instruction);
                 std::vector<std::shared_ptr<MJOLNIR::IRExpr>> parameters;
 
-                size_t p_size = call_inst->get_array_size();
+                size_t const p_size = call_inst->get_array_size();
 
                 for (size_t i = 0; i < p_size; i++)
                     parameters.push_back(make_android_register(call_inst->get_operand_register(i)));
@@ -1188,7 +1188,7 @@ namespace KUNAI
                 auto call_inst = reinterpret_cast<DEX::Instruction3rc*>(instruction);
                 std::vector<std::shared_ptr<MJOLNIR::IRExpr>> parameters;
 
-                size_t p_size = call_inst->get_array_size();
+                size_t const p_size = call_inst->get_array_size();
 
                 for (size_t i = 0; i < p_size; i++)
                     parameters.push_back(make_android_register(call_inst->get_operand_register(i)));
@@ -1361,7 +1361,7 @@ namespace KUNAI
                 auto condition = make_android_register(instr->get_array_ref());
 
                 std::vector<std::int32_t> targets;
-                std::vector<std::int32_t> checks;
+                std::vector<std::int32_t> const checks;
 
                 auto packed_switch = instr->get_packed_switch();
                 auto switch_targets = packed_switch->get_targets();
@@ -1568,7 +1568,7 @@ namespace KUNAI
             auto reg1 = make_android_register(instr->get_first_check_reg());
             auto reg2 = make_android_register(instr->get_second_check_reg());
 
-            uint64_t target = current_idx + (instr->get_ref() * 2);
+            uint64_t const target = current_idx + (instr->get_ref() * 2);
 
             auto bcomp = std::make_shared<MJOLNIR::IRBComp>(comparison, temp_reg, reg1, reg2);
             auto ir_cond = std::make_shared<MJOLNIR::IRCJmp>(target, temp_reg, nullptr, nullptr);
@@ -1585,7 +1585,7 @@ namespace KUNAI
             auto temp_reg = make_temporal_register();
             auto reg = make_android_register(instr->get_check_reg());
 
-            uint64_t target = current_idx + (instr->get_ref() * 2);
+            uint64_t const target = current_idx + (instr->get_ref() * 2);
 
             auto zcomp = std::make_shared<MJOLNIR::IRZComp>(comparison, temp_reg, reg);
             auto ir_cond = std::make_shared<MJOLNIR::IRCJmp>(target, temp_reg, nullptr, nullptr);
@@ -1731,7 +1731,7 @@ namespace KUNAI
             std::string field_type_class = "";
             size_t type_size;
             std::stringstream type_name;
-            std::string field_name = *field->get_name_idx();
+            std::string const field_name = *field->get_name_idx();
 
             if (field->get_type_idx()->get_type() == DEX::Type::FUNDAMENTAL)
             {

--- a/src/mjolnIR/ir_type.cpp
+++ b/src/mjolnIR/ir_type.cpp
@@ -297,14 +297,14 @@ namespace KUNAI
         {
             if (a.is_signed)
             {
-                int64_t result = static_cast<int64_t>(a.value) + static_cast<int64_t>(b.value);
-                IRConstInt res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
+                int64_t const result = static_cast<int64_t>(a.value) + static_cast<int64_t>(b.value);
+                IRConstInt const res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
 
                 return res;
             }
-            uint64_t result = a.value + b.value;
+            uint64_t const result = a.value + b.value;
 
-            IRConstInt res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
+            IRConstInt const res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
             return res;
         }
 
@@ -312,14 +312,14 @@ namespace KUNAI
         {
             if (a.is_signed)
             {
-                int64_t result = static_cast<int64_t>(a.value) - static_cast<int64_t>(b.value);
-                IRConstInt res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
+                int64_t const result = static_cast<int64_t>(a.value) - static_cast<int64_t>(b.value);
+                IRConstInt const res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
 
                 return res;
             }
-            uint64_t result = a.value - b.value;
+            uint64_t const result = a.value - b.value;
 
-            IRConstInt res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
+            IRConstInt const res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
             return res;
         }
 
@@ -327,14 +327,14 @@ namespace KUNAI
         {
             if (a.is_signed)
             {
-                int64_t result = static_cast<int64_t>(a.value) / static_cast<int64_t>(b.value);
-                IRConstInt res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
+                int64_t const result = static_cast<int64_t>(a.value) / static_cast<int64_t>(b.value);
+                IRConstInt const res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
 
                 return res;
             }
-            uint64_t result = a.value / b.value;
+            uint64_t const result = a.value / b.value;
 
-            IRConstInt res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
+            IRConstInt const res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
             return res;
         }
 
@@ -342,14 +342,14 @@ namespace KUNAI
         {
             if (a.is_signed)
             {
-                int64_t result = static_cast<int64_t>(a.value) * static_cast<int64_t>(b.value);
-                IRConstInt res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
+                int64_t const result = static_cast<int64_t>(a.value) * static_cast<int64_t>(b.value);
+                IRConstInt const res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
 
                 return res;
             }
-            uint64_t result = a.value * b.value;
+            uint64_t const result = a.value * b.value;
 
-            IRConstInt res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
+            IRConstInt const res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
             return res;
         }
 
@@ -357,86 +357,86 @@ namespace KUNAI
         {
             if (a.is_signed)
             {
-                int64_t result = static_cast<int64_t>(a.value) % static_cast<int64_t>(b.value);
-                IRConstInt res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
+                int64_t const result = static_cast<int64_t>(a.value) % static_cast<int64_t>(b.value);
+                IRConstInt const res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
 
                 return res;
             }
-            uint64_t result = a.value % b.value;
+            uint64_t const result = a.value % b.value;
 
-            IRConstInt res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
+            IRConstInt const res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
             return res;
         }
 
         IRConstInt operator&(IRConstInt &a, IRConstInt &b)
         {
-            uint64_t result = a.value & b.value;
+            uint64_t const result = a.value & b.value;
 
-            IRConstInt res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
+            IRConstInt const res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
             return res;
         }
 
         IRConstInt operator|(IRConstInt &a, IRConstInt &b)
         {
-            uint64_t result = a.value | b.value;
+            uint64_t const result = a.value | b.value;
 
-            IRConstInt res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
+            IRConstInt const res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
             return res;
         }
 
         IRConstInt operator^(IRConstInt &a, IRConstInt &b)
         {
-            uint64_t result = a.value ^ b.value;
+            uint64_t const result = a.value ^ b.value;
 
-            IRConstInt res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
+            IRConstInt const res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
             return res;
         }
 
         IRConstInt operator<<(IRConstInt &a, IRConstInt &b)
         {
-            uint64_t result = a.value << b.value;
+            uint64_t const result = a.value << b.value;
 
-            IRConstInt res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
+            IRConstInt const res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
             return res;
         }
 
         IRConstInt operator>>(IRConstInt &a, IRConstInt &b)
         {
-            uint64_t result = a.value >> b.value;
+            uint64_t const result = a.value >> b.value;
 
-            IRConstInt res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
+            IRConstInt const res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
             return res;
         }
 
         IRConstInt operator++(IRConstInt &a, int)
         {
-            uint64_t result = a.value++;
+            uint64_t const result = a.value++;
 
-            IRConstInt res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
+            IRConstInt const res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
             return res;
         }
 
         IRConstInt operator--(IRConstInt &a, int)
         {
-            uint64_t result = a.value--;
+            uint64_t const result = a.value--;
 
-            IRConstInt res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
+            IRConstInt const res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
             return res;
         }
 
         IRConstInt operator!(IRConstInt &a)
         {
-            uint64_t result = !a.value;
+            uint64_t const result = !a.value;
 
-            IRConstInt res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
+            IRConstInt const res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
             return res;
         }
 
         IRConstInt operator~(IRConstInt &a)
         {
-            uint64_t result = ~a.value;
+            uint64_t const result = ~a.value;
 
-            IRConstInt res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
+            IRConstInt const res(result, a.is_signed, a.byte_order, a.get_type_name(), a.get_type_size());
             return res;
         }
 
@@ -612,8 +612,8 @@ namespace KUNAI
             if (type1.addr != 0 && (type1.addr == type2.addr))
                 return true;
             // check for whole method
-            std::string callee1 = type1.class_name + type1.name + type1.description;
-            std::string callee2 = type2.class_name + type2.name + type2.description;
+            std::string const callee1 = type1.class_name + type1.name + type1.description;
+            std::string const callee2 = type2.class_name + type2.name + type2.description;
             if (!(callee1.compare(callee2)))
                 return true;
             return false;


### PR DESCRIPTION
Fixes: https://github.com/Fare9/KUNAI-static-analyzer/issues/21
`clang-tidy-15` was used for the task of appending `const` keyword to required files in the codebase.

The following command was used to automatically append the `const` keyword to the required parts of the code:
`clang-tidy-15 --fix --checks='misc-const-correctness' src/**/*.cpp`

**@Fare9  Could you kindly set a review over the current proposal?**
Kindly consider that this is my first attempt to get hands-on the codebase.

Tested build:
`cmake . -Bbuild && cmake --build build -j8`