### PR TITLE
Add const qualifier to variables that could use it

### DIFF
--- a/kunai-lib/lib/DEX/DVM/dalvik_instructions.cpp
+++ b/kunai-lib/lib/DEX/DVM/dalvik_instructions.cpp
@@ -98,7 +98,7 @@ Instruction21h::Instruction21h(std::vector<uint8_t> &bytecode, std::size_t index
 {
     op = op_codes[0];
     vAA = op_codes[1];
-    std::int16_t nBBBB_aux = *(reinterpret_cast<std::int16_t *>(&op_codes[2]));
+    std::int16_t const nBBBB_aux = *(reinterpret_cast<std::int16_t *>(&op_codes[2]));
 
     switch (op)
     {

--- a/kunai-lib/lib/DEX/DVM/recursive_traversal_disassembler.cpp
+++ b/kunai-lib/lib/DEX/DVM/recursive_traversal_disassembler.cpp
@@ -39,8 +39,6 @@ void RecursiveTraversalDisassembler::disassembly(std::vector<std::uint8_t> &buff
     auto buffer_size = buffer_bytes.size();
     // opcode
     std::uint32_t opcode;
-    // check if the method contains a switch
-    bool exist_switch = false;
 
     auto exceptions = disassembler->determine_exception(method);
 

--- a/kunai-lib/lib/DEX/analysis/basic_blocks.cpp
+++ b/kunai-lib/lib/DEX/analysis/basic_blocks.cpp
@@ -13,7 +13,8 @@ using namespace KUNAI::DEX;
 void BasicBlocks::remove_node(DVMBasicBlock *node)
 {
     // with this we provide RAII
-    std::unique_ptr<DVMBasicBlock> node_ (node);
+    // TODO: Remove unused variable
+    std::unique_ptr<DVMBasicBlock> const node_ (node);
 
     if (std::find(nodes.begin(), nodes.end(), node) == nodes.end())
         throw exceptions::AnalysisException("remove_mode: given node does not exist in graph");

--- a/kunai-lib/lib/DEX/analysis/dex_analysis.cpp
+++ b/kunai-lib/lib/DEX/analysis/dex_analysis.cpp
@@ -341,7 +341,7 @@ void Analysis::_create_xrefs(ClassDef *current_class)
 MethodAnalysis *Analysis::_resolve_method(std::string &class_name,
                                           std::string &method_name, std::string &method_descriptor)
 {
-    std::string m_hash = class_name + method_name + method_descriptor;
+    std::string const m_hash = class_name + method_name + method_descriptor;
     std::vector<std::unique_ptr<Instruction>> empty_instructions;
 
     auto it = method_hashes.find(m_hash);
@@ -387,7 +387,7 @@ std::vector<FieldAnalysis *> &Analysis::get_fields()
 std::vector<ClassAnalysis *> Analysis::find_classes(std::string &name, bool no_external = false)
 {
     std::vector<ClassAnalysis *> found_classes;
-    std::regex class_name_regex(name);
+    std::regex const class_name_regex(name);
 
     for (const auto &c : classes)
     {
@@ -432,7 +432,7 @@ std::vector<MethodAnalysis *> Analysis::find_methods(std::string &class_name,
 std::vector<StringAnalysis *> Analysis::find_strings(std::string &str)
 {
     std::vector<StringAnalysis *> strings_list;
-    std::regex str_reg(str);
+    std::regex const str_reg(str);
 
     for (const auto &s : strings)
     {

--- a/kunai-lib/lib/DEX/parser/classes.cpp
+++ b/kunai-lib/lib/DEX/parser/classes.cpp
@@ -28,10 +28,10 @@ void ClassDataItem::parse_class_data_item(
     std::uint64_t code_offset;  // offset for parsing
 
     // read the sizes of the different variables
-    std::uint64_t static_fields_size = stream->read_uleb128();
-    std::uint64_t instance_fields_size = stream->read_uleb128();
-    std::uint64_t direct_methods_size = stream->read_uleb128();
-    std::uint64_t virtual_methods_size = stream->read_uleb128();
+    std::uint64_t const static_fields_size = stream->read_uleb128();
+    std::uint64_t const instance_fields_size = stream->read_uleb128();
+    std::uint64_t const direct_methods_size = stream->read_uleb128();
+    std::uint64_t const virtual_methods_size = stream->read_uleb128();
 
     for (I = 0; I < static_fields_size; ++I)
     {

--- a/kunai-lib/lib/DEX/parser/strings.cpp
+++ b/kunai-lib/lib/DEX/parser/strings.cpp
@@ -40,7 +40,6 @@ void Strings::parse_strings(std::uint32_t strings_offset,
 
     // values
     std::uint32_t str_offset;
-    std::string str;
 
     // move to the offset where are the strings ids
     stream->seekg(strings_offset, std::ios_base::beg);


### PR DESCRIPTION
Fixes: https://github.com/Fare9/KUNAI-static-analyzer/issues/21
`clang-tidy-15` was used for the task of appending `const` keyword to required files in the codebase.

The following command was used to automatically append the `const` keyword to the required parts of the code:
```bash
clang-tidy-15 --fix --system-headers --checks='misc-const-correctness' -p build lib/**/*.cpp
```

**@Fare9  Could you kindly set a review over the current proposal?**
Kindly consider that this is my first attempt to get hands-on the codebase.

Command line for procedure:
```bash
cmake . -Bbuild -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCMAKE_BUILD_TYPE=DEBUG -DUNIT_TESTING=ON
clang-tidy-15 --fix --system-headers --checks='misc-const-correctness' -p build lib/**/*.cpp
```

[Build log](https://github.com/Fare9/KUNAI-static-analyzer/files/11073159/build_pr_60.log)
