### PR TITLE
spdlog library version bump 1.5.0 -> 1.13.0

### DIFF
--- a/kunai-lib/externals/CMakeLists.txt
+++ b/kunai-lib/externals/CMakeLists.txt
@@ -30,7 +30,7 @@ FetchContent_Declare(
     spdlog
 
     GIT_REPOSITORY https://github.com/gabime/spdlog.git
-    GIT_TAG v1.5.0
+    GIT_TAG v1.13.0
 )
 
 FetchContent_GetProperties(spdlog)


### PR DESCRIPTION
Solves #63.

The spdlog library external dependency version has been updated to comply with proper maintenance of the library. Considering the fact that no breaking changes were introduced in the library, no source-code re-work was required to be performed.

Evidence of proper build:
![image](https://github.com/Fare9/KUNAI-static-analyzer/assets/25695302/b26dcf49-da7c-4165-b237-320f6e89a4ce)


